### PR TITLE
Let README point to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,7 @@
 # Pinwheel: Android SDK
 
-Pinwheel-android will help you easly integrate Link into your android application.
+This is the Android SDK for integrating the [Pinwheel link modal](https://docs.getpinwheel.com/link/index.html) to your app.
 
-## Setup
+## Documentation
 
-In `gradle.properties` file, provide a `CDN_URL`
-
-## minSdkVersion
-
-```minSdkVersion 22```
-
-## Integration
-
-### Gradle
-```implementation 'com.underdog_tech.pinwheel:pinwheel-android:1.0.0'```
-
-### PinwheelFragment
-Sdk provides the `PinwheelFragment` that takes `linkToken: String` as an argument. 
-([Learn how to get the linkToken.](https://docs.getpinwheel.com/api-reference/index.html#create-link-token))<br/>
-`PinwheelFragment` has `newInstance(linkToken: String)` method but it is ok to use different way to pass the argument.
-If `linkToken` is not present, fragment will throw `IllegalStateException`.
-
-### PinwheelEventListener
-To listen for the events coming from the Link, implement `PinwheelEventListener`. <br/>
-Then simply provide the instance of listener to `PinwheelFragment` by setting `pinwheelEventListener` field.
-
-```kotlin
-interface PinwheelEventListener {
-
-    fun onSuccess(successEvent: PinwheelSuccessEvent)
-
-    fun onExit(exitEvent: PinwheelExitEvent)
-
-    fun onEvent(actionEvent: PinwheelActionEvent)
-}
-```
+You can fine updated documentation for Android SDK usage [here](https://docs.getpinwheel.com/link/index.html#android)


### PR DESCRIPTION
We should merge in [this PR](https://github.com/underdog-tech/docs/pull/58/files) first before merging this change to the README. The thought is that the docs website is the official source of truth and we only need to ever update the usage docs there and not have to keep two places in sync with eachother.