### PR TITLE
Adds pendingRetry to Error type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "com.underdog_tech.pinwheel_android_demo"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 8
-        versionName "2.0.0"
+        versionCode 9
+        versionName "2.2.0"
 
         buildConfigField "String", "API_SECRET", "\"${API_SECRET}\""
 

--- a/pinwheel-android/build.gradle
+++ b/pinwheel-android/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 def libraryGroupId = 'com.underdog_tech.pinwheel'
 def libraryArtifactId = 'pinwheel-android'
-def libraryVersion = '2.0.0'
+def libraryVersion = '2.2.0'
 afterEvaluate {
     publishing {
         publications {
@@ -50,7 +50,7 @@ android {
     defaultConfig {
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 2
+        versionCode 3
         versionName libraryVersion
         buildConfigField "String", "LIBRARY_VERSION", "\"${libraryVersion}\""
 

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/Pinwheel.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/Pinwheel.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.full.memberFunctions
 
 object Pinwheel {
 
-    const val CDN_URL= "https://cdn.getpinwheel.com/link-v3.2.0.html"
+    const val CDN_URL= "https://cdn.getpinwheel.com/link-v2.2.0.html"
 
     fun init(webView: WebView, linkToken: String, callback: PinwheelEventListener?) {
         val timestamp = getUnixTimestamp()

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/Pinwheel.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/Pinwheel.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.full.memberFunctions
 
 object Pinwheel {
 
-    const val CDN_URL= "https://cdn.getpinwheel.com/link-v3.0.0-beta.html"
+    const val CDN_URL= "https://cdn.getpinwheel.com/link-v3.2.0.html"
 
     fun init(webView: WebView, linkToken: String, callback: PinwheelEventListener?) {
         val timestamp = getUnixTimestamp()

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
@@ -37,6 +37,7 @@ data class PinwheelError(
     val type: String,
     val code: String,
     val message: String,
+    val pendingRetry: Boolean,
 ): PinwheelEventPayload
 
 data class PinwheelSelectedEmployerPayload(


### PR DESCRIPTION
## Description of the change

Error objects coming from Jarvis will now include a `pendingRetry` boolean attribute. Creating a new minor version of the SDK here to capture that.

The jump from 2.0.0 to 2.2.0 is because we should have bumped it to 2.1.0 in the last release so this is keeping it consistent with the other SDKs.

**_Wait for Link v2.2 to be deployed before merging and deploying._**

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://pinwheel.atlassian.net/browse/PP-4623

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
