### PR TITLE
Add github release publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,3 +189,5 @@ workflows:
               only:
                 - release
                 - robby/github-releases
+          requires:
+            - test_unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,5 @@ workflows:
             branches:
               only:
                 - release
-                - robby/github-releases
           requires:
             - test_unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,23 @@ jobs:
           name: Publish to GitHub
           command: ./gradlew publish
 
+  github_release:
+    working_directory: *workspace
+    docker:
+      - image: cimg/go:1.16.3
+    steps:
+      - checkout
+      - run:
+          name: "Install ghr"
+          command: |
+            go get github.com/tcnksm/ghr
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            VERSION=$(cat pinwheel-android/build.gradle | grep 'def libraryVersion' | cut -d"'" -f 2)
+            echo ${VERSION}
+            ghr -t ${GPR_API_KEY} ${VERSION} .
+
 workflows:
   version: 2
   workflow:
@@ -166,3 +183,9 @@ workflows:
           requires:
             - test_unit
 
+      - github_release:
+          filters:
+            branches:
+              only:
+                - release
+                - robby/github-releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
           command: |
             VERSION=$(cat pinwheel-android/build.gradle | grep 'def libraryVersion' | cut -d"'" -f 2)
             echo ${VERSION}
-            ghr -t ${GPR_API_KEY} ${VERSION} .
+            ghr -t ${GPR_API_KEY} -delete ${VERSION} .
 
 workflows:
   version: 2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 include ':pinwheel-android'
-include ':app'
 rootProject.name = "link-android-sdk"


### PR DESCRIPTION
## Description of the change

This changes the CircleCI config to publish releases to GitHub. We can then use Jitpack to distribute builds

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
