### PR TITLE
Update to open external links in separate app

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ repositories {
 4. Add the package to your dependencies:
 ```gradle
 dependencies {
-    implementation 'com.underdog_tech.pinwheel:pinwheel-android:2.3.0'
+    implementation 'com.underdog_tech.pinwheel:pinwheel-android:2.3.1'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "com.underdog_tech.pinwheel_android_demo"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 11
-        versionName "2.3.0"
+        versionCode 12
+        versionName "2.3.1"
 
         buildConfigField "String", "API_SECRET", "\"${API_SECRET}\""
 

--- a/pinwheel-android/build.gradle
+++ b/pinwheel-android/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 def libraryGroupId = 'com.underdog_tech.pinwheel'
 def libraryArtifactId = 'pinwheel-android'
-def libraryVersion = '2.3.0'
+def libraryVersion = '2.3.1'
 
 afterEvaluate {
     publishing {
@@ -53,7 +53,7 @@ android {
     defaultConfig {
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 5
+        versionCode 6
         versionName libraryVersion
         buildConfigField "String", "LIBRARY_VERSION", "\"${libraryVersion}\""
 

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelWebViewClient.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelWebViewClient.kt
@@ -2,7 +2,6 @@ package com.underdog_tech.pinwheel_android.webview
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelWebViewClient.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelWebViewClient.kt
@@ -1,5 +1,9 @@
 package com.underdog_tech.pinwheel_android.webview
 
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.underdog_tech.pinwheel_android.BuildConfig
@@ -14,6 +18,12 @@ class PinwheelWebViewClient(
 
     override fun onPageFinished(view: WebView?, url: String?) {
         view?.let { injectJS(it) }
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        val i = Intent(Intent.ACTION_VIEW, Uri.parse(request.url.toString()))
+        view.context.startActivity(i)
+        return true
     }
 
     private fun injectJS(view: WebView) {


### PR DESCRIPTION
## Description of the change

If an external link is present such as the current ones to go to the provider's own website for account recovery, we would want it to open in a separate app vs. within the iFrame.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://pinwheel.atlassian.net/browse/PP-5158

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
