### PR TITLE
Add missing field for login event

### DIFF
--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
@@ -52,6 +52,7 @@ data class PinwheelSelectedPlatformPayload(
 
 data class PinwheelLoginPayload(
     val accountId: String,
+    val platformId: String,
 ): PinwheelEventPayload
 
 


### PR DESCRIPTION
## Description of the change

The `platformId` field was missing from the model object, so it is not being included in the event payload. Note that we don't currently have unit tests set up for these events, so I'll add one for this whenever I tackle [PP-5215](https://pinwheel.atlassian.net/browse/PP-5215)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [PP-5212](https://pinwheel.atlassian.net/browse/PP-5212) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
