### PR TITLE
Add rules to prevent stripping of JS interfaces, and GSON events

### DIFF
--- a/pinwheel-android/consumer-rules.pro
+++ b/pinwheel-android/consumer-rules.pro
@@ -1,0 +1,7 @@
+-keepclassmembers class ** {
+  @android.webkit.JavascriptInterface public *;
+}
+
+-keepclassmembers class ** implements com.underdog_tech.pinwheel_android.model.PinwheelEventPayload {
+  *;
+}


### PR DESCRIPTION
## Description of the change

Add R8 rules to prevent stripping of JS interfaces, and GSON events.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
