### PR TITLE
Fix error parsing in the onExit callback

### DIFF
--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
@@ -47,7 +47,7 @@ class PinwheelJavaScriptInterface(private val pinwheelEventListener: PinwheelEve
                         var error: PinwheelError? = null;
 
                         if (payload.has("error")) {
-                            error = gson.fromJson(payload, PinwheelError::class.java)
+                            error = gson.fromJson(payload.get("error"), PinwheelError::class.java)
                         }
 
                         it.onEvent(PinwheelEventType.EXIT, error)


### PR DESCRIPTION
When the Javascript interface bridges the `onExit` callback, it tries to parse the error from the payload. It checks for an `error` element, but then tries to parse it at the top level so it gets null for all of the fields.