### PR TITLE
Mark the params field of the success event payload as optional

### DIFF
--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
@@ -30,7 +30,7 @@ data class PinwheelParams(
 data class PinwheelResult(
     val accountId: String,
     val job: String,
-    val params: PinwheelParams,
+    val params: PinwheelParams?,
 ): PinwheelEventPayload
 
 data class PinwheelError(


### PR DESCRIPTION
The success event contains a `params` object with some amount data. It's marked as non-nullable but it isn't always set in JSON payload. So Gson parses it as null and then it throws an NPE at runtime when you try to access it.

iOS already [marks the field as nullable](https://github.com/underdog-tech/pinwheel-ios-sdk/blob/0a33090e71f522a0b821318a8278782e61ab1f69/Sources/PinwheelSDK/Classes/Events/PinwheelSuccessPayload.swift#L13), so this brings Android to parity.