### PR TITLE
Add a simple view of Link events

### DIFF
--- a/app/src/main/java/com/underdog_tech/pinwheel_android_demo/repository/model/CapturedEvent.kt
+++ b/app/src/main/java/com/underdog_tech/pinwheel_android_demo/repository/model/CapturedEvent.kt
@@ -1,0 +1,5 @@
+package com.underdog_tech.pinwheel_android_demo.repository.model
+
+import java.io.Serializable
+
+data class CapturedEvent(val eventName: String, var payload: String?) : Serializable

--- a/app/src/main/java/com/underdog_tech/pinwheel_android_demo/ui/main/EventsFragment.kt
+++ b/app/src/main/java/com/underdog_tech/pinwheel_android_demo/ui/main/EventsFragment.kt
@@ -1,0 +1,50 @@
+package com.underdog_tech.pinwheel_android_demo.ui.main
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.ListView
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.underdog_tech.pinwheel_android_demo.R
+import com.underdog_tech.pinwheel_android_demo.repository.model.CapturedEvent
+
+class EventsFragment(val capturedEvents: MutableList<CapturedEvent>) : Fragment(R.layout.events_fragment) {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.events_fragment, container, false)
+        val listView = view.findViewById<ListView>(R.id.events_listview)
+        if (listView != null) {
+            listView.adapter = EventsAdapter(inflater.context, capturedEvents)
+        }
+        return view
+    }
+
+
+    private class EventsAdapter(context: Context, events: MutableList<CapturedEvent>) : BaseAdapter() {
+        private val mContext: Context = context
+        private val mEvents: MutableList<CapturedEvent> = events
+
+        override fun getCount(): Int {
+            return mEvents.count()
+        }
+        override fun getItemId(position: Int): Long {
+            return position.toLong()
+        }
+        override fun getItem(position: Int): String {
+            return mEvents.get(position).eventName.toString()
+        }
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+            var tv = TextView(mContext)
+            val event = mEvents.get(position)
+            tv.text = event.eventName + " - " + event.payload
+            return tv
+        }
+    }
+}

--- a/app/src/main/java/com/underdog_tech/pinwheel_android_demo/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/underdog_tech/pinwheel_android_demo/ui/main/MainFragment.kt
@@ -12,12 +12,15 @@ import com.underdog_tech.pinwheel_android.PinwheelFragment
 import com.underdog_tech.pinwheel_android.model.*
 import com.underdog_tech.pinwheel_android_demo.R
 import com.underdog_tech.pinwheel_android_demo.databinding.MainFragmentBinding
+import com.underdog_tech.pinwheel_android_demo.repository.model.CapturedEvent
 import kotlinx.android.synthetic.main.main_fragment.*
 import timber.log.Timber
 
 class MainFragment : Fragment(), PinwheelEventListener {
 
     private lateinit var viewModel: MainViewModel
+
+    val capturedEvents = mutableListOf<CapturedEvent>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -68,9 +71,16 @@ class MainFragment : Fragment(), PinwheelEventListener {
         Timber.d("ON EXIT: %s", error)
         parentFragmentManager.popBackStack()
         Toast.makeText(context, "Pinwheel On Exit Event Fired", Toast.LENGTH_LONG).show()
+
+        parentFragmentManager.let {
+            val transaction = it.beginTransaction()
+            val eventsFragment = EventsFragment(capturedEvents)
+            transaction.replace(R.id.rootView, eventsFragment).addToBackStack("events").commit()
+        }
     }
 
     override fun onEvent(eventName: PinwheelEventType, payload: PinwheelEventPayload?) {
+        capturedEvents.add(CapturedEvent(eventName.toString(), payload.toString()))
         Timber.d("ON EVENT: %s %s", eventName, payload)
     }
 

--- a/app/src/main/res/layout/events_fragment.xml
+++ b/app/src/main/res/layout/events_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ListView
+        android:id="@+id/events_listview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </ListView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pinwheel-android/build.gradle
+++ b/pinwheel-android/build.gradle
@@ -56,11 +56,11 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    testImplementation "androidx.fragment:fragment-testing:1.2.5"
+    testImplementation 'androidx.fragment:fragment-testing:1.2.5'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:2.18.3'
-    testImplementation "org.robolectric:robolectric:4.4"
+    testImplementation 'org.robolectric:robolectric:4.4'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }


### PR DESCRIPTION
## Description of the change

This PR adds a very simple ListView of events that were emitted during the Link flow.

![image](https://user-images.githubusercontent.com/2034490/134207803-878e2fd1-0377-4b9d-8f38-3f6f299f29d4.png)


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

