### PR TITLE
Move api secret to a global gradle variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Optional callback for when an error occurs.
 
 ## Example
 
-An example project is provided in the app directory. Add `include ':app'` to `settings.gradle`. Also add your API secret to `gradle.properties`. This is done purely for ease of testing the sample app. In your production app, you should fetch the Link token from your server, and you should never include your API secret in your app.
+An example project is provided in the app directory. Add `include ':app'` to `settings.gradle`. Add your API secret as a global gradle property, `PINWHEEL_API_SECRET` in `$USER_HOME/.gradle/gradle.properties`. This is done purely for ease of testing the sample app. In your production app, you should fetch the Link token from your server, and you should never include your API secret in your app.
 
 ### Make Feature
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         versionCode 13
         versionName "2.3.11"
 
-        buildConfigField "String", "API_SECRET", "\"${API_SECRET}\""
+        buildConfigField 'String', 'API_SECRET', PINWHEEL_API_SECRET
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-
-API_SECRET=yoursecret


### PR DESCRIPTION
## Description of the change

This PR moves the `API_SECRET` out of the project's `gradle.properties` in favor of the global one.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
