### PR TITLE
Remove Jitpack support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,6 @@ references:
         - ~/.gradle
         - ~/.m2
 
-  add_gradle_properties: &add_gradle_properties
-    run: 
-      name: Add gradle global properties
-      command: echo PINWHEEL_API_SECRET=$PINWHEEL_API_SECRET > ~/.gradle/gradle.properties
-
   save_gems_cache: &save_gems_cache
     save_cache:
       key: *gems_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
     steps:
       - checkout
       - *restore_gradle_cache
-      - *add_gradle_properties
       - *restore_gems_cache
       - *ruby_dependencies
       - *create_keystore_properties
@@ -112,7 +111,6 @@ jobs:
     steps:
       - checkout
       - *restore_gradle_cache
-      - *add_gradle_properties
       - *restore_gems_cache
       - *ruby_dependencies
       - *create_keystore_properties

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
     steps:
       - checkout
       - *restore_gradle_cache
+      - *add_gradle_properties
       - *restore_gems_cache
       - *ruby_dependencies
       - *create_keystore_properties
@@ -111,6 +112,7 @@ jobs:
     steps:
       - checkout
       - *restore_gradle_cache
+      - *add_gradle_properties
       - *restore_gems_cache
       - *ruby_dependencies
       - *create_keystore_properties

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: ./gradlew test
+          command: ./gradlew pinwheel-android:test
 
       - store_artifacts:
           path: app/build/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ references:
         - ~/.gradle
         - ~/.m2
 
+  add_gradle_properties: &add_gradle_properties
+    run: 
+      name: Add gradle global properties
+      command: echo PINWHEEL_API_SECRET=$PINWHEEL_API_SECRET > ~/.gradle/gradle.properties
+
   save_gems_cache: &save_gems_cache
     save_cache:
       key: *gems_key

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Pinwheel Android SDK's main interface is a `Fragment` that you can integrate
 
 ### Installation
 
-The Pinwheel Android SDK is available via [Maven Central Repository](https://search.maven.org/artifact/com.getpinwheel/pinwheel-android), [JitPack](https://jitpack.io/#underdog-tech/pinwheel-android-sdk), and [GitHub Packages](https://github.com/underdog-tech/pinwheel-android-sdk/packages/719840).
+The Pinwheel Android SDK is available via [Maven Central Repository](https://search.maven.org/artifact/com.getpinwheel/pinwheel-android), and [GitHub Packages](https://github.com/underdog-tech/pinwheel-android-sdk/packages/719840).
 
 #### Maven Central Repository
 To install the SDK using the Maven Central Repository

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Pinwheel Android SDK's main interface is a `Fragment` that you can integrate
 
 ### Installation
 
-The Pinwheel Android SDK is available via [Maven Central Repository](https://search.maven.org/artifact/com.getpinwheel/pinwheel-android), and [GitHub Packages](https://github.com/underdog-tech/pinwheel-android-sdk/packages/719840).
+The Pinwheel Android SDK is available via [Maven Central Repository](https://search.maven.org/artifact/com.getpinwheel/pinwheel-android) and [GitHub Packages](https://github.com/underdog-tech/pinwheel-android-sdk/packages/719840).
 
 #### Maven Central Repository
 To install the SDK using the Maven Central Repository

--- a/README.md
+++ b/README.md
@@ -30,26 +30,6 @@ dependencies {
 
 3. Sync your Android gradle project and the library should be ready to use.
 
-#### JitPack
-To install the SDK using JitPack:
-1. Add  the JitPack url to your app's `build.gradle` file:
-```gradle
-repositories {
-    maven {
-        url 'https://jitpack.io'
-    }
-}
-```
-
-2. Add the package to your dependencies:
-```gradle
-dependencies {
-    implementation 'com.github.underdog-tech:pinwheel-android-sdk:2.3.11'
-}
-```
-
-3. Sync your Android gradle project and the library should be ready to use.
-
 
 #### GitHub Package
 To install the SDK using GitHub packages:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':pinwheel-android'
+include ':app'
 rootProject.name = "link-android-sdk"


### PR DESCRIPTION
## Description of the change

Deprecate Jitpack support. While removing it from the docs doesn't actually disable Jitpack from working, we don't want to encourage customers to use it any more.
