### PR TITLE
Add support for login_attempt event

### DIFF
--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/PinwheelEventListener.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/PinwheelEventListener.kt
@@ -5,6 +5,8 @@ import com.underdog_tech.pinwheel_android.model.*
 interface PinwheelEventListener {
     fun onLogin(result: PinwheelLoginPayload) {}
 
+    fun onLoginAttempt(result: PinwheelLoginAttemptPayload) {}
+
     fun onSuccess(result: PinwheelResult) {}
 
     fun onError(error: PinwheelError) {}

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
@@ -12,6 +12,7 @@ enum class PinwheelEventType {
     EXIT,
     SUCCESS,
     LOGIN,
+    LOGIN_ATTEMPT,
     ERROR,
     INCORRECT_PLATFORM_GIVEN
 }
@@ -52,6 +53,10 @@ data class PinwheelSelectedPlatformPayload(
 
 data class PinwheelLoginPayload(
     val accountId: String,
+    val platformId: String,
+): PinwheelEventPayload
+
+data class PinwheelLoginAttemptPayload(
     val platformId: String,
 ): PinwheelEventPayload
 

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
@@ -69,6 +69,14 @@ class PinwheelJavaScriptInterface(private val pinwheelEventListener: PinwheelEve
                         it.onEvent(PinwheelEventType.LOGIN, result)
                         it.onLogin(result)
                     }
+                    "login_attempt" -> {
+                        val result: PinwheelLoginAttemptPayload = gson.fromJson(
+                            payload,
+                            PinwheelLoginAttemptPayload::class.java
+                        )
+                        it.onEvent(PinwheelEventType.LOGIN_ATTEMPT, result)
+                        it.onLoginAttempt(result)
+                    }
                     "error" -> {
                         val error: PinwheelError = gson.fromJson(
                             payload,


### PR DESCRIPTION
## Description of the change

Add support for login_attempt event which includes:
- New EventType: `LOGIN_ATTEMPT`
- New PinwheelEventPayload: `PinwheelLoginAttemptPayload`
- New PinwheelEventListener function: `onLoginAttempt(result: PinwheelLoginAttemptPayload)`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
