### PR TITLE
Adding GitHub PR Action integration with Phylum

### DIFF
--- a/.github/workflows/phylum_pr.yml
+++ b/.github/workflows/phylum_pr.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze_PR_with_Phylum_job:
+    runs-on: ubuntu-latest
+    name: A job to analyze PR with phylum
+    steps:
+      - uses: actions/checkout@v2
+      - id: analyze-pr-test
+        uses: peterjmorgan/phylum-analyze-pr-action@v1.1
+        with:
+          phylum_username: ${{ secrets.PHYLUM_USER }}
+          phylum_password: ${{ secrets.PHYLUM_PASS }}


### PR DESCRIPTION
## Description of the change

Adding a GitHub PR Action workflow to integrate with Phylum, so when we detect a package lock change, we can scan for vulnerabilities and license issues.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
