### PR TITLE
We need thresholds set otherwise the PR Action has errors

### DIFF
--- a/.github/workflows/phylum_pr.yml
+++ b/.github/workflows/phylum_pr.yml
@@ -10,7 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: analyze-pr-test
-        uses: peterjmorgan/phylum-analyze-pr-action@v1.1
+        uses: phylum-dev/phylum-analyze-pr-action@v1.2
         with:
+          vul_threshold: 0.6
+          mal_threshold: 0.6
+          eng_threshold: 0.6
+          lic_threshold: 0.6
+          aut_threshold: 0.6
           phylum_username: ${{ secrets.PHYLUM_USER }}
           phylum_password: ${{ secrets.PHYLUM_PASS }}


### PR DESCRIPTION
## Description of the change

We need to set thresholds for the PR Action workflow for Phylum otherwise it errors. These weren't set due to a miscommunication between myself and Phylum on implementation.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
