### PR TITLE
Add DD forms client events

### DIFF
--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/model/PinwheelEvent.kt
@@ -18,6 +18,9 @@ enum class PinwheelEventType {
     ERROR,
     INCORRECT_PLATFORM_GIVEN,
     CARD_SWITCH_BEGIN,
+    DD_FORM_BEGIN,
+    DD_FORM_CREATE,
+    DD_FORM_DOWNLOAD,
 }
 
 const val EVENT_MESSAGE = "PINWHEEL_EVENT"
@@ -78,6 +81,10 @@ data class PinwheelLoginPayload(
 
 data class PinwheelLoginAttemptPayload(
     val platformId: String,
+): PinwheelEventPayload
+
+data class PinwheelDDFormCreatePayload(
+    val url: String,
 ): PinwheelEventPayload
 
 

--- a/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
+++ b/pinwheel-android/src/main/java/com/underdog_tech/pinwheel_android/webview/PinwheelJavaScriptInterface.kt
@@ -100,6 +100,18 @@ class PinwheelJavaScriptInterface(private val pinwheelEventListener: PinwheelEve
                     "card_switch_begin" -> {
                         it.onEvent(PinwheelEventType.CARD_SWITCH_BEGIN, null)
                     }
+                    "dd_form_begin" -> {
+                        it.onEvent(PinwheelEventType.DD_FORM_BEGIN, null)
+                    }
+                    "dd_form_create" -> {
+                        it.onEvent(
+                            PinwheelEventType.DD_FORM_CREATE,
+                            gson.fromJson(payload, PinwheelDDFormCreatePayload::class.java)
+                        )
+                    }
+                    "dd_form_download" -> {
+                        it.onEvent(PinwheelEventType.DD_FORM_DOWNLOAD, null)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description of the change

Add DD forms client events:
* `dd_form_begin`
* `dd_form_create: { url: string } `
* `dd_form_download`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [DD-310](https://pinwheel.atlassian.net/browse/DD-310)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


[DD-310]: https://pinwheel.atlassian.net/browse/DD-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ